### PR TITLE
Add expansion filtering support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ ValhallaNodes brings World of Warcraft gathering nodes back from the afterlife. 
 Run the `valhalla_nodes.py` script. Select the node types and expansion you want, choose an output directory, and click **Run**. Lua files will be created in the selected directory. Copy them into your `World of Warcraft/_retail_/Interface/AddOns/GatherMate2_Data/` folder.
 
 ## Extending Map and Node IDs
-Map and node IDs are loaded from `map_ids.json` and `node_ids.json`. Edit these files to add new expansions or nodes. Each file uses simple key/value pairs to map names to IDs.
+Map and node IDs are loaded from `map_ids.json` and `node_ids.json`. Edit these files to add new maps or nodes. Each file uses simple key/value pairs to map names to IDs.
+
+Expansions are mapped to lists of zone IDs using `expansions.json`. The GUI drop-down is populated from this file so you can easily add support for future content.
 
 ```json
 {

--- a/expansions.json
+++ b/expansions.json
@@ -1,0 +1,4 @@
+{
+  "Dragonflight": [2112, 2025, 2024],
+  "The War Within": [2291, 2292]
+}

--- a/valhalla_nodes.py
+++ b/valhalla_nodes.py
@@ -143,9 +143,12 @@ class ValhallaNodesApp:
 
         # Expansion dropdown
         tk.Label(frame, text="Expansion:").grid(row=1, column=0, sticky="w", pady=(5, 0))
-        self.expansion_var = tk.StringVar(value="Dragonflight")
+        # Expansion mapping loaded from JSON so users can extend it
+        self.expansion_map = load_json("expansions.json")
+        expansions = list(self.expansion_map) if self.expansion_map else ["Dragonflight", "The War Within"]
+        self.expansion_var = tk.StringVar(value=expansions[0])
         self.expansion_box = ttk.Combobox(frame, textvariable=self.expansion_var, state="readonly")
-        self.expansion_box["values"] = ["Dragonflight", "The War Within"]
+        self.expansion_box["values"] = expansions
         self.expansion_box.grid(row=1, column=1, sticky="w", pady=(5, 0))
 
         # Output directory selector
@@ -179,6 +182,7 @@ class ValhallaNodesApp:
 
     def run(self) -> None:
         expansion = self.expansion_var.get()
+        allowed_ids = set(self.expansion_map.get(expansion, []))
         out_dir = self.out_dir_var.get()
         for node_type, var in self.node_vars.items():
             if not var.get():
@@ -186,6 +190,13 @@ class ValhallaNodesApp:
             nodes = scrape_nodes(node_type, expansion, self.log_write)
             if not nodes:
                 continue
+            if allowed_ids:
+                filtered = []
+                for item in nodes:
+                    m_id = self.map_ids.get(item["map_name"])
+                    if m_id in allowed_ids:
+                        filtered.append(item)
+                nodes = filtered
             export_lua(node_type, nodes, self.map_ids, self.node_ids, out_dir)
         messagebox.showinfo("ValhallaNodes", "Export complete")
 


### PR DESCRIPTION
## Summary
- allow loading expansions from `expansions.json`
- filter scraped nodes by the selected expansion
- document expandable expansions file

## Testing
- `python3 -m py_compile valhalla_nodes.py`

------
https://chatgpt.com/codex/tasks/task_e_6859b8fe544c832aa6179ec34abd8b9b